### PR TITLE
Make NSCoding / SwiftyJSON optional, add ObjectMapper, add specific numerical types.

### DIFF
--- a/SwiftyJSONAccelerator.xcodeproj/project.pbxproj
+++ b/SwiftyJSONAccelerator.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		93F174601BD070AA007E7DFC /* JSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F1745F1BD070AA007E7DFC /* JSONHelper.swift */; };
 		C667011B1BDCABCE009BA254 /* SwiftyJSONTemplate.txt in Resources */ = {isa = PBXBuildFile; fileRef = C667011A1BDCABCE009BA254 /* SwiftyJSONTemplate.txt */; };
 		C667011D1BDCAF23009BA254 /* ObjectMapperTemplate.txt in Resources */ = {isa = PBXBuildFile; fileRef = C667011C1BDCAF23009BA254 /* ObjectMapperTemplate.txt */; };
+		C667011F1BDCBE1F009BA254 /* NSCodingTemplate.txt in Resources */ = {isa = PBXBuildFile; fileRef = C667011E1BDCBE1F009BA254 /* NSCodingTemplate.txt */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +54,7 @@
 		93F1745F1BD070AA007E7DFC /* JSONHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONHelper.swift; sourceTree = "<group>"; };
 		C667011A1BDCABCE009BA254 /* SwiftyJSONTemplate.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SwiftyJSONTemplate.txt; sourceTree = "<group>"; };
 		C667011C1BDCAF23009BA254 /* ObjectMapperTemplate.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ObjectMapperTemplate.txt; sourceTree = "<group>"; };
+		C667011E1BDCBE1F009BA254 /* NSCodingTemplate.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = NSCodingTemplate.txt; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -79,6 +81,7 @@
 				9341A14E1BD6E7290048CE2C /* BaseTemplate.txt */,
 				C667011A1BDCABCE009BA254 /* SwiftyJSONTemplate.txt */,
 				C667011C1BDCAF23009BA254 /* ObjectMapperTemplate.txt */,
+				C667011E1BDCBE1F009BA254 /* NSCodingTemplate.txt */,
 			);
 			path = "Base Files";
 			sourceTree = "<group>";
@@ -235,6 +238,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C667011B1BDCABCE009BA254 /* SwiftyJSONTemplate.txt in Resources */,
+				C667011F1BDCBE1F009BA254 /* NSCodingTemplate.txt in Resources */,
 				93F174471BD0707D007E7DFC /* Assets.xcassets in Resources */,
 				C667011D1BDCAF23009BA254 /* ObjectMapperTemplate.txt in Resources */,
 				9341A14F1BD6E7290048CE2C /* BaseTemplate.txt in Resources */,

--- a/SwiftyJSONAccelerator.xcodeproj/project.pbxproj
+++ b/SwiftyJSONAccelerator.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		93F1744A1BD0707D007E7DFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 93F174481BD0707D007E7DFC /* Main.storyboard */; };
 		93F174551BD0707D007E7DFC /* SwiftyJSONAcceleratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F174541BD0707D007E7DFC /* SwiftyJSONAcceleratorTests.swift */; };
 		93F174601BD070AA007E7DFC /* JSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F1745F1BD070AA007E7DFC /* JSONHelper.swift */; };
+		C667011B1BDCABCE009BA254 /* SwiftyJSONTemplate.txt in Resources */ = {isa = PBXBuildFile; fileRef = C667011A1BDCABCE009BA254 /* SwiftyJSONTemplate.txt */; };
+		C667011D1BDCAF23009BA254 /* ObjectMapperTemplate.txt in Resources */ = {isa = PBXBuildFile; fileRef = C667011C1BDCAF23009BA254 /* ObjectMapperTemplate.txt */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +51,8 @@
 		93F174541BD0707D007E7DFC /* SwiftyJSONAcceleratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftyJSONAcceleratorTests.swift; sourceTree = "<group>"; };
 		93F174561BD0707D007E7DFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		93F1745F1BD070AA007E7DFC /* JSONHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONHelper.swift; sourceTree = "<group>"; };
+		C667011A1BDCABCE009BA254 /* SwiftyJSONTemplate.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SwiftyJSONTemplate.txt; sourceTree = "<group>"; };
+		C667011C1BDCAF23009BA254 /* ObjectMapperTemplate.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ObjectMapperTemplate.txt; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,6 +77,8 @@
 			isa = PBXGroup;
 			children = (
 				9341A14E1BD6E7290048CE2C /* BaseTemplate.txt */,
+				C667011A1BDCABCE009BA254 /* SwiftyJSONTemplate.txt */,
+				C667011C1BDCAF23009BA254 /* ObjectMapperTemplate.txt */,
 			);
 			path = "Base Files";
 			sourceTree = "<group>";
@@ -228,7 +234,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C667011B1BDCABCE009BA254 /* SwiftyJSONTemplate.txt in Resources */,
 				93F174471BD0707D007E7DFC /* Assets.xcassets in Resources */,
+				C667011D1BDCAF23009BA254 /* ObjectMapperTemplate.txt in Resources */,
 				9341A14F1BD6E7290048CE2C /* BaseTemplate.txt in Resources */,
 				93F1744A1BD0707D007E7DFC /* Main.storyboard in Resources */,
 			);

--- a/SwiftyJSONAccelerator/Base Files/BaseTemplate.txt
+++ b/SwiftyJSONAccelerator/Base Files/BaseTemplate.txt
@@ -5,9 +5,9 @@
 //  Copyright (c) __MyCompanyName__. All rights reserved.
 //
 
-import Foundation{INCLUDE_SWIFTY}
+import Foundation{INCLUDE_SWIFTY}{INCLUDE_OBJECT_MAPPER}
 
-public {OBJECT_KIND} {OBJECT_NAME}: NSObject, NSCoding {
+public {OBJECT_KIND} {OBJECT_NAME}: {OBJECT_BASE_CLASS}{NSCODING_PROTOCOL_SUPPORT} {
 
         // MARK: Declaration for string constants to be used to decode and also serialize.
     {STRING_CONSTANT_BLOCK}
@@ -16,23 +16,9 @@ public {OBJECT_KIND} {OBJECT_NAME}: NSObject, NSCoding {
     {PROPERTIES}
 
         // MARK: Initalizers
-        /**
-        Initates the class based on the object
-        - parameter object: The object of either Dictionary or Array kind that was passed.
-        - returns: An initalized instance of the class.
-        */
-        convenience public init(object: AnyObject) {
-            self.init(json: JSON(object))
-        }
+{SWIFTY_JSON_SUPPORT}
 
-        /**
-        Initates the class based on the JSON that was passed.
-        - parameter json: JSON object from SwiftyJSON.
-        - returns: An initalized instance of the class.
-        */
-        public init(json: JSON) {
-    {INITALIZER}
-        }
+{OBJECT_MAPPER_SUPPORT}
 
         /**
         Generates description of the object in the form of a NSDictionary.
@@ -40,10 +26,10 @@ public {OBJECT_KIND} {OBJECT_NAME}: NSObject, NSCoding {
         */
         public func dictionaryRepresentation() -> [String : AnyObject ] {
 
-        var dictionary: [String : AnyObject ] = [ : ]
-    {DESC}
+            var dictionary: [String : AnyObject ] = [ : ]
+        {DESC}
 
-        return dictionary
+            return dictionary
         }
 
     {NSCODING_SUPPORT}

--- a/SwiftyJSONAccelerator/Base Files/BaseTemplate.txt
+++ b/SwiftyJSONAccelerator/Base Files/BaseTemplate.txt
@@ -9,28 +9,28 @@ import Foundation{INCLUDE_SWIFTY}{INCLUDE_OBJECT_MAPPER}
 
 public {OBJECT_KIND} {OBJECT_NAME}: {OBJECT_BASE_CLASS}{NSCODING_PROTOCOL_SUPPORT} {
 
-        // MARK: Declaration for string constants to be used to decode and also serialize.
-    {STRING_CONSTANT_BLOCK}
+    // MARK: Declaration for string constants to be used to decode and also serialize.
+{STRING_CONSTANT_BLOCK}
 
-        // MARK: Properties
-    {PROPERTIES}
+    // MARK: Properties
+{PROPERTIES}
 
-        // MARK: Initalizers
+    // MARK: Initalizers
 {SWIFTY_JSON_SUPPORT}
 
 {OBJECT_MAPPER_SUPPORT}
 
-        /**
-        Generates description of the object in the form of a NSDictionary.
-        - returns: A Key value pair containing all valid values in the object.
-        */
-        public func dictionaryRepresentation() -> [String : AnyObject ] {
+    /**
+    Generates description of the object in the form of a NSDictionary.
+    - returns: A Key value pair containing all valid values in the object.
+    */
+    public func dictionaryRepresentation() -> [String : AnyObject ] {
 
-            var dictionary: [String : AnyObject ] = [ : ]
-        {DESC}
+        var dictionary: [String : AnyObject ] = [ : ]
+{DESC}
 
-            return dictionary
-        }
+        return dictionary
+    }
 
     {NSCODING_SUPPORT}
 

--- a/SwiftyJSONAccelerator/Base Files/BaseTemplate.txt
+++ b/SwiftyJSONAccelerator/Base Files/BaseTemplate.txt
@@ -9,50 +9,43 @@ import Foundation{INCLUDE_SWIFTY}
 
 public {OBJECT_KIND} {OBJECT_NAME}: NSObject, NSCoding {
 
-	// MARK: Declaration for string constants to be used to decode and also serialize.
-{STRING_CONSTANT_BLOCK}
+        // MARK: Declaration for string constants to be used to decode and also serialize.
+    {STRING_CONSTANT_BLOCK}
 
-	// MARK: Properties
-{PROPERTIES}
+        // MARK: Properties
+    {PROPERTIES}
 
-	// MARK: Initalizers
-    /**
-    Initates the class based on the object
-    - parameter object: The object of either Dictionary or Array kind that was passed.
-    - returns: An initalized instance of the class.
-    */
-    convenience public init(object: AnyObject) {
-        self.init(json: JSON(object))
-    }
+        // MARK: Initalizers
+        /**
+        Initates the class based on the object
+        - parameter object: The object of either Dictionary or Array kind that was passed.
+        - returns: An initalized instance of the class.
+        */
+        convenience public init(object: AnyObject) {
+            self.init(json: JSON(object))
+        }
 
-    /**
-    Initates the class based on the JSON that was passed.
-    - parameter json: JSON object from SwiftyJSON.
-    - returns: An initalized instance of the class.
-    */
-    public init(json: JSON) {
-{INITALIZER}
-    }
+        /**
+        Initates the class based on the JSON that was passed.
+        - parameter json: JSON object from SwiftyJSON.
+        - returns: An initalized instance of the class.
+        */
+        public init(json: JSON) {
+    {INITALIZER}
+        }
 
-    /**
-    Generates description of the object in the form of a NSDictionary.
-    - returns: A Key value pair containing all valid values in the object.
-    */
-    public func dictionaryRepresentation() -> [String : AnyObject ] {
+        /**
+        Generates description of the object in the form of a NSDictionary.
+        - returns: A Key value pair containing all valid values in the object.
+        */
+        public func dictionaryRepresentation() -> [String : AnyObject ] {
 
-    var dictionary: [String : AnyObject ] = [ : ]
-{DESC}
+        var dictionary: [String : AnyObject ] = [ : ]
+    {DESC}
 
-    return dictionary
-    }
+        return dictionary
+        }
 
-    // MARK: NSCoding Protocol
-    required public init(coder aDecoder: NSCoder) {
-{DECODERS}
-    }
-
-    public func encodeWithCoder(aCoder: NSCoder) {
-{ENCODERS}
-    }
+    {NSCODING_SUPPORT}
 
 }

--- a/SwiftyJSONAccelerator/Base Files/NSCodingTemplate.txt
+++ b/SwiftyJSONAccelerator/Base Files/NSCodingTemplate.txt
@@ -1,0 +1,8 @@
+    // MARK: NSCoding Protocol
+    required public init(coder aDecoder: NSCoder) {
+        {DECODERS}
+    }
+
+    public func encodeWithCoder(aCoder: NSCoder) {
+        {ENCODERS}
+    }

--- a/SwiftyJSONAccelerator/Base Files/NSCodingTemplate.txt
+++ b/SwiftyJSONAccelerator/Base Files/NSCodingTemplate.txt
@@ -1,8 +1,8 @@
-    // MARK: NSCoding Protocol
+// MARK: NSCoding Protocol
     required public init(coder aDecoder: NSCoder) {
-        {DECODERS}
+{DECODERS}
     }
 
     public func encodeWithCoder(aCoder: NSCoder) {
-        {ENCODERS}
+{ENCODERS}
     }

--- a/SwiftyJSONAccelerator/Base Files/ObjectMapperTemplate.txt
+++ b/SwiftyJSONAccelerator/Base Files/ObjectMapperTemplate.txt
@@ -1,0 +1,15 @@
+        /**
+        Map a JSON object to this class using ObjectMapper
+        - parameter map: A mapping from ObjectMapper
+        */
+        required init?(_ map: Map){
+
+        }
+
+        /**
+        Map a JSON object to this class using ObjectMapper
+        - parameter map: A mapping from ObjectMapper
+        */
+        func mapping(map: Map) {
+{OBJECT_MAPPER_INITIALIZER}
+        }

--- a/SwiftyJSONAccelerator/Base Files/ObjectMapperTemplate.txt
+++ b/SwiftyJSONAccelerator/Base Files/ObjectMapperTemplate.txt
@@ -1,15 +1,15 @@
-        /**
-        Map a JSON object to this class using ObjectMapper
-        - parameter map: A mapping from ObjectMapper
-        */
-        required init?(_ map: Map){
+    /**
+    Map a JSON object to this class using ObjectMapper
+    - parameter map: A mapping from ObjectMapper
+    */
+    required init?(_ map: Map){
 
-        }
+    }
 
-        /**
-        Map a JSON object to this class using ObjectMapper
-        - parameter map: A mapping from ObjectMapper
-        */
-        func mapping(map: Map) {
+    /**
+    Map a JSON object to this class using ObjectMapper
+    - parameter map: A mapping from ObjectMapper
+    */
+    func mapping(map: Map) {
 {OBJECT_MAPPER_INITIALIZER}
-        }
+    }

--- a/SwiftyJSONAccelerator/Base Files/SwiftyJSONTemplate.txt
+++ b/SwiftyJSONAccelerator/Base Files/SwiftyJSONTemplate.txt
@@ -1,17 +1,17 @@
-        /**
-        Initates the class based on the object
-        - parameter object: The object of either Dictionary or Array kind that was passed.
-        - returns: An initalized instance of the class.
-        */
-        convenience public init(object: AnyObject) {
+    /**
+    Initates the class based on the object
+    - parameter object: The object of either Dictionary or Array kind that was passed.
+    - returns: An initalized instance of the class.
+    */
+    convenience public init(object: AnyObject) {
         self.init(json: JSON(object))
-        }
+    }
 
-        /**
-        Initates the class based on the JSON that was passed.
-        - parameter json: JSON object from SwiftyJSON.
-        - returns: An initalized instance of the class.
-        */
-        public init(json: JSON) {
-        {INITALIZER}
-        }
+    /**
+    Initates the class based on the JSON that was passed.
+    - parameter json: JSON object from SwiftyJSON.
+    - returns: An initalized instance of the class.
+    */
+    public init(json: JSON) {
+{INITALIZER}
+    }

--- a/SwiftyJSONAccelerator/Base Files/SwiftyJSONTemplate.txt
+++ b/SwiftyJSONAccelerator/Base Files/SwiftyJSONTemplate.txt
@@ -1,0 +1,17 @@
+        /**
+        Initates the class based on the object
+        - parameter object: The object of either Dictionary or Array kind that was passed.
+        - returns: An initalized instance of the class.
+        */
+        convenience public init(object: AnyObject) {
+        self.init(json: JSON(object))
+        }
+
+        /**
+        Initates the class based on the JSON that was passed.
+        - parameter json: JSON object from SwiftyJSON.
+        - returns: An initalized instance of the class.
+        */
+        public init(json: JSON) {
+        {INITALIZER}
+        }

--- a/SwiftyJSONAccelerator/Base.lproj/Main.storyboard
+++ b/SwiftyJSONAccelerator/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15A284" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15A282b" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9059"/>
@@ -670,11 +670,11 @@
             <objects>
                 <viewController title="SwiftyJSONAccelerator" id="XfG-lQ-9wD" customClass="SJEditorViewController" customModule="SwiftyJSONAccelerator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="m2S-Jp-Qdl">
-                        <rect key="frame" x="0.0" y="0.0" width="717" height="628"/>
+                        <rect key="frame" x="0.0" y="0.0" width="717" height="645"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AwX-MF-DMD">
-                                <rect key="frame" x="501" y="126" width="212" height="36"/>
+                                <rect key="frame" x="501" y="143" width="212" height="36"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="Fsx-eV-1MY"/>
                                 </constraints>
@@ -688,7 +688,7 @@
                                 </connections>
                             </button>
                             <scrollView horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gmg-Tp-PPn">
-                                <rect key="frame" x="0.0" y="165" width="717" height="463"/>
+                                <rect key="frame" x="0.0" y="182" width="717" height="463"/>
                                 <clipView key="contentView" id="V7d-R1-cDN">
                                     <rect key="frame" x="1" y="1" width="715" height="461"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -699,10 +699,10 @@
                                             <animations/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                                            <size key="minSize" width="715" height="461"/>
+                                            <size key="minSize" width="700" height="461"/>
                                             <size key="maxSize" width="717" height="10000000"/>
                                             <color key="insertionPointColor" name="controlLightHighlightColor" catalog="System" colorSpace="catalog"/>
-                                            <size key="minSize" width="715" height="461"/>
+                                            <size key="minSize" width="700" height="461"/>
                                             <size key="maxSize" width="717" height="10000000"/>
                                         </textView>
                                     </subviews>
@@ -716,13 +716,13 @@
                                     <animations/>
                                 </scroller>
                                 <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="9fh-RH-upi">
-                                    <rect key="frame" x="700" y="1" width="16" height="461"/>
+                                    <rect key="frame" x="701" y="1" width="15" height="461"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <animations/>
                                 </scroller>
                             </scrollView>
                             <imageView translatesAutoresizingMaskIntoConstraints="NO" id="PJA-AP-s5I">
-                                <rect key="frame" x="15" y="138" width="20" height="20"/>
+                                <rect key="frame" x="15" y="155" width="20" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="48s-vB-xta"/>
                                     <constraint firstAttribute="width" constant="20" id="t6S-fb-bjE"/>
@@ -731,7 +731,7 @@
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" image="failure" id="CKF-pW-DBY"/>
                             </imageView>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GbJ-FJ-Uuc">
-                                <rect key="frame" x="41" y="132" width="460" height="26"/>
+                                <rect key="frame" x="41" y="149" width="460" height="26"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="26" id="WGF-kR-SB9"/>
                                 </constraints>
@@ -743,7 +743,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aJ1-yn-Pl7">
-                                <rect key="frame" x="13" y="106" width="692" height="22"/>
+                                <rect key="frame" x="13" y="123" width="692" height="22"/>
                                 <animations/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="BaseClass" placeholderString="Base Class Name" bezelStyle="round" id="vuP-t4-ep6">
                                     <font key="font" metaFont="system"/>
@@ -752,7 +752,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="b3c-Wz-v36">
-                                <rect key="frame" x="13" y="82" width="692" height="22"/>
+                                <rect key="frame" x="13" y="99" width="692" height="22"/>
                                 <animations/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Class Prefix (For example, NS)" bezelStyle="round" id="N8s-m9-cf7">
                                     <font key="font" metaFont="system"/>
@@ -761,7 +761,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sNu-7Z-F06">
-                                <rect key="frame" x="13" y="58" width="692" height="22"/>
+                                <rect key="frame" x="13" y="75" width="692" height="22"/>
                                 <animations/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Company name" bezelStyle="round" id="76e-Gm-0jI">
                                     <font key="font" metaFont="system"/>
@@ -770,7 +770,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mJg-3P-2Aw">
-                                <rect key="frame" x="13" y="34" width="692" height="22"/>
+                                <rect key="frame" x="13" y="51" width="692" height="22"/>
                                 <animations/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Author name" bezelStyle="round" id="jUe-0u-QLL">
                                     <font key="font" metaFont="system"/>
@@ -779,9 +779,17 @@
                                 </textFieldCell>
                             </textField>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="uZa-9r-6Xo">
-                                <rect key="frame" x="13" y="10" width="265" height="18"/>
+                                <rect key="frame" x="13" y="27" width="265" height="18"/>
                                 <animations/>
                                 <buttonCell key="cell" type="check" title="Add &quot;import SwiftyJSON&quot; in the models." bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="tJK-cs-wrm">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                            </button>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="or1-PD-m0L">
+                                <rect key="frame" x="13" y="7" width="265" height="18"/>
+                                <animations/>
+                                <buttonCell key="cell" type="check" title="Support NSCoding" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="YUy-wn-qL0">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -789,8 +797,8 @@
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="AwX-MF-DMD" secondAttribute="trailing" constant="10" id="1wF-Ly-8ue"/>
-                            <constraint firstAttribute="bottom" secondItem="uZa-9r-6Xo" secondAttribute="bottom" constant="12" id="33g-aa-kCl"/>
                             <constraint firstItem="aJ1-yn-Pl7" firstAttribute="leading" secondItem="mJg-3P-2Aw" secondAttribute="leading" id="35V-f8-AGH"/>
+                            <constraint firstItem="or1-PD-m0L" firstAttribute="top" secondItem="uZa-9r-6Xo" secondAttribute="bottom" constant="6" id="8NF-CF-XQV"/>
                             <constraint firstItem="b3c-Wz-v36" firstAttribute="width" secondItem="mJg-3P-2Aw" secondAttribute="width" id="8wA-lO-d5e"/>
                             <constraint firstItem="aJ1-yn-Pl7" firstAttribute="width" secondItem="mJg-3P-2Aw" secondAttribute="width" id="9m4-gy-MnL"/>
                             <constraint firstAttribute="trailing" secondItem="Gmg-Tp-PPn" secondAttribute="trailing" id="APF-Xg-5Am"/>
@@ -800,10 +808,13 @@
                             <constraint firstItem="GbJ-FJ-Uuc" firstAttribute="top" secondItem="PJA-AP-s5I" secondAttribute="top" id="IlE-F0-NZD"/>
                             <constraint firstItem="aJ1-yn-Pl7" firstAttribute="top" secondItem="AwX-MF-DMD" secondAttribute="bottom" constant="5" id="KM7-XP-CAY"/>
                             <constraint firstItem="Gmg-Tp-PPn" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" id="KPd-r3-s21"/>
+                            <constraint firstAttribute="bottom" secondItem="or1-PD-m0L" secondAttribute="bottom" constant="9" id="Klb-Me-gMO"/>
+                            <constraint firstItem="or1-PD-m0L" firstAttribute="width" secondItem="uZa-9r-6Xo" secondAttribute="width" id="OdK-JX-tBs"/>
                             <constraint firstItem="b3c-Wz-v36" firstAttribute="leading" secondItem="mJg-3P-2Aw" secondAttribute="leading" id="Q9g-6W-fq3"/>
                             <constraint firstItem="sNu-7Z-F06" firstAttribute="top" secondItem="b3c-Wz-v36" secondAttribute="bottom" constant="2" id="Svz-9v-6zt"/>
                             <constraint firstItem="PJA-AP-s5I" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="15" id="ZKf-XD-X3C"/>
                             <constraint firstItem="uZa-9r-6Xo" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="15" id="ZT5-69-AWH"/>
+                            <constraint firstItem="or1-PD-m0L" firstAttribute="leading" secondItem="uZa-9r-6Xo" secondAttribute="leading" id="aLP-RS-Gyu"/>
                             <constraint firstItem="AwX-MF-DMD" firstAttribute="top" secondItem="Gmg-Tp-PPn" secondAttribute="bottom" constant="7" id="cHK-Sj-6ps"/>
                             <constraint firstItem="uZa-9r-6Xo" firstAttribute="top" secondItem="mJg-3P-2Aw" secondAttribute="bottom" constant="8" id="dno-LM-r3L"/>
                             <constraint firstItem="AwX-MF-DMD" firstAttribute="top" secondItem="PJA-AP-s5I" secondAttribute="top" id="ds3-Tk-TKg"/>
@@ -826,12 +837,13 @@
                         <outlet property="includeSwiftyCheckbox" destination="uZa-9r-6Xo" id="r84-Fc-xwG"/>
                         <outlet property="messageLabel" destination="GbJ-FJ-Uuc" id="19Z-0L-YwW"/>
                         <outlet property="prefixClassTextField" destination="b3c-Wz-v36" id="3wr-bV-AAf"/>
+                        <outlet property="supportNSCodingCheckbox" destination="or1-PD-m0L" id="wyH-nh-iSo"/>
                         <outlet property="textView" destination="fWl-7Q-Cq6" id="1lh-CW-y1Y"/>
                     </connections>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="151.5" y="651"/>
+            <point key="canvasLocation" x="819.5" y="504.5"/>
         </scene>
     </scenes>
     <resources>

--- a/SwiftyJSONAccelerator/Base.lproj/Main.storyboard
+++ b/SwiftyJSONAccelerator/Base.lproj/Main.storyboard
@@ -670,11 +670,11 @@
             <objects>
                 <viewController title="SwiftyJSONAccelerator" id="XfG-lQ-9wD" customClass="SJEditorViewController" customModule="SwiftyJSONAccelerator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="m2S-Jp-Qdl">
-                        <rect key="frame" x="0.0" y="0.0" width="717" height="645"/>
+                        <rect key="frame" x="0.0" y="0.0" width="717" height="706"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AwX-MF-DMD">
-                                <rect key="frame" x="501" y="143" width="212" height="36"/>
+                                <rect key="frame" x="501" y="204" width="212" height="36"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="Fsx-eV-1MY"/>
                                 </constraints>
@@ -688,7 +688,7 @@
                                 </connections>
                             </button>
                             <scrollView horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gmg-Tp-PPn">
-                                <rect key="frame" x="0.0" y="182" width="717" height="463"/>
+                                <rect key="frame" x="0.0" y="243" width="717" height="463"/>
                                 <clipView key="contentView" id="V7d-R1-cDN">
                                     <rect key="frame" x="1" y="1" width="715" height="461"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -722,7 +722,7 @@
                                 </scroller>
                             </scrollView>
                             <imageView translatesAutoresizingMaskIntoConstraints="NO" id="PJA-AP-s5I">
-                                <rect key="frame" x="15" y="155" width="20" height="20"/>
+                                <rect key="frame" x="15" y="216" width="20" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="48s-vB-xta"/>
                                     <constraint firstAttribute="width" constant="20" id="t6S-fb-bjE"/>
@@ -731,7 +731,7 @@
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" image="failure" id="CKF-pW-DBY"/>
                             </imageView>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GbJ-FJ-Uuc">
-                                <rect key="frame" x="41" y="149" width="460" height="26"/>
+                                <rect key="frame" x="41" y="210" width="460" height="26"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="26" id="WGF-kR-SB9"/>
                                 </constraints>
@@ -743,7 +743,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aJ1-yn-Pl7">
-                                <rect key="frame" x="13" y="123" width="692" height="22"/>
+                                <rect key="frame" x="13" y="184" width="692" height="22"/>
                                 <animations/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="BaseClass" placeholderString="Base Class Name" bezelStyle="round" id="vuP-t4-ep6">
                                     <font key="font" metaFont="system"/>
@@ -752,7 +752,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="b3c-Wz-v36">
-                                <rect key="frame" x="13" y="99" width="692" height="22"/>
+                                <rect key="frame" x="13" y="160" width="692" height="22"/>
                                 <animations/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Class Prefix (For example, NS)" bezelStyle="round" id="N8s-m9-cf7">
                                     <font key="font" metaFont="system"/>
@@ -761,7 +761,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sNu-7Z-F06">
-                                <rect key="frame" x="13" y="75" width="692" height="22"/>
+                                <rect key="frame" x="13" y="136" width="692" height="22"/>
                                 <animations/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Company name" bezelStyle="round" id="76e-Gm-0jI">
                                     <font key="font" metaFont="system"/>
@@ -770,7 +770,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mJg-3P-2Aw">
-                                <rect key="frame" x="13" y="51" width="692" height="22"/>
+                                <rect key="frame" x="13" y="112" width="692" height="22"/>
                                 <animations/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Author name" bezelStyle="round" id="jUe-0u-QLL">
                                     <font key="font" metaFont="system"/>
@@ -779,44 +779,80 @@
                                 </textFieldCell>
                             </textField>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="uZa-9r-6Xo">
-                                <rect key="frame" x="13" y="27" width="265" height="18"/>
+                                <rect key="frame" x="41" y="48" width="265" height="18"/>
                                 <animations/>
                                 <buttonCell key="cell" type="check" title="Add &quot;import SwiftyJSON&quot; in the models." bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="tJK-cs-wrm">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                             </button>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="cd4-4Z-P4h">
+                                <rect key="frame" x="13" y="68" width="240" height="18"/>
+                                <animations/>
+                                <buttonCell key="cell" type="check" title="Support importing from SwiftyJSON" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="JTr-D4-Ydb">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="recalcEnabledBoxes:" target="XfG-lQ-9wD" id="xJS-rQ-k1k"/>
+                                </connections>
+                            </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="or1-PD-m0L">
-                                <rect key="frame" x="13" y="7" width="265" height="18"/>
+                                <rect key="frame" x="13" y="88" width="265" height="18"/>
                                 <animations/>
                                 <buttonCell key="cell" type="check" title="Support NSCoding" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="YUy-wn-qL0">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                             </button>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="DfN-HB-jLF">
+                                <rect key="frame" x="41" y="8" width="280" height="18"/>
+                                <animations/>
+                                <buttonCell key="cell" type="check" title="Add &quot;import ObjectMapper&quot; in the models." bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="LOO-Pz-Jiw">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                            </button>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="Cqf-Zq-qhb">
+                                <rect key="frame" x="13" y="28" width="230" height="18"/>
+                                <animations/>
+                                <buttonCell key="cell" type="check" title="Support Hearst-DD/ObjectMapper" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="vuk-4k-MY7">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="recalcEnabledBoxes:" target="XfG-lQ-9wD" id="Vu8-i2-A3h"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="cd4-4Z-P4h" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="15" id="11Y-ht-hKx"/>
                             <constraint firstAttribute="trailing" secondItem="AwX-MF-DMD" secondAttribute="trailing" constant="10" id="1wF-Ly-8ue"/>
                             <constraint firstItem="aJ1-yn-Pl7" firstAttribute="leading" secondItem="mJg-3P-2Aw" secondAttribute="leading" id="35V-f8-AGH"/>
-                            <constraint firstItem="or1-PD-m0L" firstAttribute="top" secondItem="uZa-9r-6Xo" secondAttribute="bottom" constant="6" id="8NF-CF-XQV"/>
                             <constraint firstItem="b3c-Wz-v36" firstAttribute="width" secondItem="mJg-3P-2Aw" secondAttribute="width" id="8wA-lO-d5e"/>
+                            <constraint firstAttribute="bottom" secondItem="DfN-HB-jLF" secondAttribute="bottom" constant="10" id="9BW-Yo-Auq"/>
                             <constraint firstItem="aJ1-yn-Pl7" firstAttribute="width" secondItem="mJg-3P-2Aw" secondAttribute="width" id="9m4-gy-MnL"/>
                             <constraint firstAttribute="trailing" secondItem="Gmg-Tp-PPn" secondAttribute="trailing" id="APF-Xg-5Am"/>
+                            <constraint firstItem="or1-PD-m0L" firstAttribute="top" secondItem="mJg-3P-2Aw" secondAttribute="bottom" constant="8" id="BEK-W3-IHq"/>
                             <constraint firstItem="sNu-7Z-F06" firstAttribute="leading" secondItem="mJg-3P-2Aw" secondAttribute="leading" id="EKU-pL-FZ6"/>
+                            <constraint firstItem="uZa-9r-6Xo" firstAttribute="top" secondItem="cd4-4Z-P4h" secondAttribute="bottom" constant="6" id="FUN-ZO-xR8"/>
                             <constraint firstItem="sNu-7Z-F06" firstAttribute="width" secondItem="mJg-3P-2Aw" secondAttribute="width" id="FdJ-wz-nzg"/>
+                            <constraint firstItem="cd4-4Z-P4h" firstAttribute="top" secondItem="or1-PD-m0L" secondAttribute="bottom" constant="6" id="HGb-5u-Za0"/>
                             <constraint firstItem="GbJ-FJ-Uuc" firstAttribute="leading" secondItem="PJA-AP-s5I" secondAttribute="trailing" constant="8" id="HqW-6O-Fdl"/>
                             <constraint firstItem="GbJ-FJ-Uuc" firstAttribute="top" secondItem="PJA-AP-s5I" secondAttribute="top" id="IlE-F0-NZD"/>
+                            <constraint firstItem="DfN-HB-jLF" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="43" id="JO5-QU-smH"/>
                             <constraint firstItem="aJ1-yn-Pl7" firstAttribute="top" secondItem="AwX-MF-DMD" secondAttribute="bottom" constant="5" id="KM7-XP-CAY"/>
                             <constraint firstItem="Gmg-Tp-PPn" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" id="KPd-r3-s21"/>
-                            <constraint firstAttribute="bottom" secondItem="or1-PD-m0L" secondAttribute="bottom" constant="9" id="Klb-Me-gMO"/>
                             <constraint firstItem="or1-PD-m0L" firstAttribute="width" secondItem="uZa-9r-6Xo" secondAttribute="width" id="OdK-JX-tBs"/>
+                            <constraint firstItem="Cqf-Zq-qhb" firstAttribute="top" secondItem="uZa-9r-6Xo" secondAttribute="bottom" constant="6" id="OzW-Gj-CmR"/>
+                            <constraint firstItem="DfN-HB-jLF" firstAttribute="top" secondItem="Cqf-Zq-qhb" secondAttribute="bottom" constant="6" id="PVQ-Cl-zPa"/>
                             <constraint firstItem="b3c-Wz-v36" firstAttribute="leading" secondItem="mJg-3P-2Aw" secondAttribute="leading" id="Q9g-6W-fq3"/>
                             <constraint firstItem="sNu-7Z-F06" firstAttribute="top" secondItem="b3c-Wz-v36" secondAttribute="bottom" constant="2" id="Svz-9v-6zt"/>
+                            <constraint firstItem="Cqf-Zq-qhb" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="15" id="Ueo-v4-wjp"/>
                             <constraint firstItem="PJA-AP-s5I" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="15" id="ZKf-XD-X3C"/>
-                            <constraint firstItem="uZa-9r-6Xo" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="15" id="ZT5-69-AWH"/>
-                            <constraint firstItem="or1-PD-m0L" firstAttribute="leading" secondItem="uZa-9r-6Xo" secondAttribute="leading" id="aLP-RS-Gyu"/>
+                            <constraint firstItem="uZa-9r-6Xo" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="43" id="ZT5-69-AWH"/>
                             <constraint firstItem="AwX-MF-DMD" firstAttribute="top" secondItem="Gmg-Tp-PPn" secondAttribute="bottom" constant="7" id="cHK-Sj-6ps"/>
-                            <constraint firstItem="uZa-9r-6Xo" firstAttribute="top" secondItem="mJg-3P-2Aw" secondAttribute="bottom" constant="8" id="dno-LM-r3L"/>
+                            <constraint firstItem="or1-PD-m0L" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="15" id="dHR-Z7-0of"/>
                             <constraint firstItem="AwX-MF-DMD" firstAttribute="top" secondItem="PJA-AP-s5I" secondAttribute="top" id="ds3-Tk-TKg"/>
                             <constraint firstItem="aJ1-yn-Pl7" firstAttribute="top" secondItem="PJA-AP-s5I" secondAttribute="bottom" constant="10" id="gHI-A7-SyE"/>
                             <constraint firstItem="mJg-3P-2Aw" firstAttribute="top" secondItem="sNu-7Z-F06" secondAttribute="bottom" constant="2" id="h24-Ox-KU7"/>
@@ -834,16 +870,19 @@
                         <outlet property="baseClassTextField" destination="aJ1-yn-Pl7" id="22H-xr-iCp"/>
                         <outlet property="companyNameTextField" destination="sNu-7Z-F06" id="1lU-Ld-bFb"/>
                         <outlet property="errorImageView" destination="PJA-AP-s5I" id="0nv-qV-54d"/>
+                        <outlet property="includeObjectMapperCheckbox" destination="DfN-HB-jLF" id="gsn-gy-cek"/>
                         <outlet property="includeSwiftyCheckbox" destination="uZa-9r-6Xo" id="r84-Fc-xwG"/>
                         <outlet property="messageLabel" destination="GbJ-FJ-Uuc" id="19Z-0L-YwW"/>
                         <outlet property="prefixClassTextField" destination="b3c-Wz-v36" id="3wr-bV-AAf"/>
                         <outlet property="supportNSCodingCheckbox" destination="or1-PD-m0L" id="wyH-nh-iSo"/>
+                        <outlet property="supportObjectMapperCheckbox" destination="Cqf-Zq-qhb" id="Bxl-UD-iag"/>
+                        <outlet property="supportSwiftyJSONCheckbox" destination="cd4-4Z-P4h" id="JHq-HI-vYJ"/>
                         <outlet property="textView" destination="fWl-7Q-Cq6" id="1lh-CW-y1Y"/>
                     </connections>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="819.5" y="504.5"/>
+            <point key="canvasLocation" x="819.5" y="535"/>
         </scene>
     </scenes>
     <resources>

--- a/SwiftyJSONAccelerator/SJEditorViewController.swift
+++ b/SwiftyJSONAccelerator/SJEditorViewController.swift
@@ -20,6 +20,7 @@ class SJEditorViewController: NSViewController, NSTextViewDelegate {
     @IBOutlet var companyNameTextField: NSTextField?
     @IBOutlet var authorNameTextField: NSTextField?
     @IBOutlet var includeSwiftyCheckbox: NSButton?
+    @IBOutlet var supportNSCodingCheckbox: NSButton!
 
     // MARK: View methods
     override func loadView() {
@@ -101,7 +102,9 @@ class SJEditorViewController: NSViewController, NSTextViewDelegate {
         if object != nil {
 
             let swiftyState = self.includeSwiftyCheckbox?.state == 1 ? true : false
-            let generator: ModelGenerator = ModelGenerator.init(baseContent: JSON(object!), prefix:  prefixClassTextField?.stringValue, baseClassName: (baseClassTextField?.stringValue)!, authorName: authorNameTextField?.stringValue, companyName: companyNameTextField?.stringValue, type: ModelType.kClassType, filePath:  filePath!, includeSwiftyJSON: swiftyState)
+            let nscodingState = self.supportNSCodingCheckbox?.state == 1 ? true : false
+
+            let generator: ModelGenerator = ModelGenerator.init(baseContent: JSON(object!), prefix:  prefixClassTextField?.stringValue, baseClassName: (baseClassTextField?.stringValue)!, authorName: authorNameTextField?.stringValue, companyName: companyNameTextField?.stringValue, type: ModelType.kClassType, filePath:  filePath!, includeSwiftyJSON: swiftyState, supportNSCoding: nscodingState)
             generator.generate()
         } else {
             let alert:NSAlert = NSAlert()

--- a/SwiftyJSONAccelerator/SJEditorViewController.swift
+++ b/SwiftyJSONAccelerator/SJEditorViewController.swift
@@ -126,21 +126,17 @@ class SJEditorViewController: NSViewController, NSTextViewDelegate {
         let supportSwiftyState = self.supportSwiftyJSONCheckbox?.state == 1 ? true : false
         let supportObjectMapperState = self.supportObjectMapperCheckbox?.state == 1 ? true : false
 
-        if supportSwiftyState
-        {
+        if supportSwiftyState {
             self.includeSwiftyCheckbox?.enabled = true
         }
-        else
-        {
+        else {
             self.includeSwiftyCheckbox?.enabled = false
         }
         
-        if supportObjectMapperState
-        {
+        if supportObjectMapperState {
             self.includeObjectMapperCheckbox?.enabled = true
         }
-        else
-        {
+        else {
             self.includeObjectMapperCheckbox?.enabled = false
         }
     }

--- a/SwiftyJSONAccelerator/SJEditorViewController.swift
+++ b/SwiftyJSONAccelerator/SJEditorViewController.swift
@@ -21,6 +21,9 @@ class SJEditorViewController: NSViewController, NSTextViewDelegate {
     @IBOutlet var authorNameTextField: NSTextField?
     @IBOutlet var includeSwiftyCheckbox: NSButton?
     @IBOutlet var supportNSCodingCheckbox: NSButton!
+    @IBOutlet var supportSwiftyJSONCheckbox: NSButton!
+    @IBOutlet var supportObjectMapperCheckbox: NSButton!
+    @IBOutlet var includeObjectMapperCheckbox: NSButton!
 
     // MARK: View methods
     override func loadView() {
@@ -102,9 +105,14 @@ class SJEditorViewController: NSViewController, NSTextViewDelegate {
         if object != nil {
 
             let swiftyState = self.includeSwiftyCheckbox?.state == 1 ? true : false
+            let supportSwiftyState = self.supportSwiftyJSONCheckbox?.state == 1 ? true : false
+            
             let nscodingState = self.supportNSCodingCheckbox?.state == 1 ? true : false
+            
+            let objectMapperState = self.includeObjectMapperCheckbox?.state == 1 ? true : false
+            let supportObjectMapperState = self.supportObjectMapperCheckbox?.state == 1 ? true : false
 
-            let generator: ModelGenerator = ModelGenerator.init(baseContent: JSON(object!), prefix:  prefixClassTextField?.stringValue, baseClassName: (baseClassTextField?.stringValue)!, authorName: authorNameTextField?.stringValue, companyName: companyNameTextField?.stringValue, type: ModelType.kClassType, filePath:  filePath!, includeSwiftyJSON: swiftyState, supportNSCoding: nscodingState)
+            let generator: ModelGenerator = ModelGenerator.init(baseContent: JSON(object!), prefix:  prefixClassTextField?.stringValue, baseClassName: (baseClassTextField?.stringValue)!, authorName: authorNameTextField?.stringValue, companyName: companyNameTextField?.stringValue, type: ModelType.kClassType, filePath:  filePath!, supportSwiftyJSON: supportSwiftyState, includeSwiftyJSON: swiftyState, supportObjectMapper: supportObjectMapperState, includeObjectMapper: objectMapperState, supportNSCoding: nscodingState)
             generator.generate()
         } else {
             let alert:NSAlert = NSAlert()
@@ -113,6 +121,30 @@ class SJEditorViewController: NSViewController, NSTextViewDelegate {
         }
     }
 
+    @IBAction func recalcEnabledBoxes(sender: AnyObject) {
+        
+        let supportSwiftyState = self.supportSwiftyJSONCheckbox?.state == 1 ? true : false
+        let supportObjectMapperState = self.supportObjectMapperCheckbox?.state == 1 ? true : false
+
+        if supportSwiftyState
+        {
+            self.includeSwiftyCheckbox?.enabled = true
+        }
+        else
+        {
+            self.includeSwiftyCheckbox?.enabled = false
+        }
+        
+        if supportObjectMapperState
+        {
+            self.includeObjectMapperCheckbox?.enabled = true
+        }
+        else
+        {
+            self.includeObjectMapperCheckbox?.enabled = false
+        }
+    }
+    
     // MARK: Internal Methods
 
     /**

--- a/SwiftyJSONAccelerator/SJModelGenerator.swift
+++ b/SwiftyJSONAccelerator/SJModelGenerator.swift
@@ -212,32 +212,26 @@ public class ModelGenerator {
             content = content.stringByReplacingOccurrencesOfString("{STRING_CONSTANT_BLOCK}", withString: stringConstants)
             content = content.stringByReplacingOccurrencesOfString("{PROPERTIES}", withString: declarations)
             
-            if self.supportNSCoding
-            {
-                if let nscodingBase = try? String(contentsOfFile: NSBundle.mainBundle().pathForResource("NSCodingTemplate", ofType: "txt")!)
-                {
+            if self.supportNSCoding {
+                if let nscodingBase = try? String(contentsOfFile: NSBundle.mainBundle().pathForResource("NSCodingTemplate", ofType: "txt")!) {
                     content = content.stringByReplacingOccurrencesOfString("{NSCODING_PROTOCOL_SUPPORT}", withString: ", NSCoding")
                     content = content.stringByReplacingOccurrencesOfString("{NSCODING_SUPPORT}", withString: nscodingBase)
 
                     content = content.stringByReplacingOccurrencesOfString("{ENCODERS}", withString: encoders)
                     content = content.stringByReplacingOccurrencesOfString("{DECODERS}", withString: decoders)
                 }
-                else
-                {
+                else {
                     content = content.stringByReplacingOccurrencesOfString("{NSCODING_PROTOCOL_SUPPORT}", withString: "")
                     content = content.stringByReplacingOccurrencesOfString("{NSCODING_SUPPORT}", withString: "")
                 }
             }
-            else
-            {
+            else {
                 content = content.stringByReplacingOccurrencesOfString("{NSCODING_PROTOCOL_SUPPORT}", withString: "")
                 content = content.stringByReplacingOccurrencesOfString("{NSCODING_SUPPORT}", withString: "")
             }
             
-            if self.supportSwiftyJSON
-            {
-                if let swiftyBase = try? String(contentsOfFile: NSBundle.mainBundle().pathForResource("SwiftyJSONTemplate", ofType: "txt")!)
-                {
+            if self.supportSwiftyJSON {
+                if let swiftyBase = try? String(contentsOfFile: NSBundle.mainBundle().pathForResource("SwiftyJSONTemplate", ofType: "txt")!) {
                     content = content.stringByReplacingOccurrencesOfString("{SWIFTY_JSON_SUPPORT}", withString: swiftyBase)
 
                     content = content.stringByReplacingOccurrencesOfString("{INITALIZER}", withString: initalizers)
@@ -248,22 +242,18 @@ public class ModelGenerator {
                         content = content.stringByReplacingOccurrencesOfString("{INCLUDE_SWIFTY}", withString: "")
                     }
                 }
-                else
-                {
+                else {
                     content = content.stringByReplacingOccurrencesOfString("{SWIFTY_JSON_SUPPORT}", withString: "")
                     content = content.stringByReplacingOccurrencesOfString("{INCLUDE_SWIFTY}", withString: "")
                 }
             }
-            else
-            {
+            else {
                 content = content.stringByReplacingOccurrencesOfString("{SWIFTY_JSON_SUPPORT}", withString: "")
                 content = content.stringByReplacingOccurrencesOfString("{INCLUDE_SWIFTY}", withString: "")
             }
             
-            if self.supportObjectMapper
-            {
-                if let objectMapperBase = try? String(contentsOfFile: NSBundle.mainBundle().pathForResource("ObjectMapperTemplate", ofType: "txt")!)
-                {
+            if self.supportObjectMapper {
+                if let objectMapperBase = try? String(contentsOfFile: NSBundle.mainBundle().pathForResource("ObjectMapperTemplate", ofType: "txt")!) {
                     content = content.stringByReplacingOccurrencesOfString("{OBJECT_MAPPER_SUPPORT}", withString: objectMapperBase)
                     
                     content = content.stringByReplacingOccurrencesOfString("{OBJECT_MAPPER_INITIALIZER}", withString: objectMapperMappings)
@@ -276,8 +266,7 @@ public class ModelGenerator {
                         content = content.stringByReplacingOccurrencesOfString("{INCLUDE_OBJECT_MAPPER}", withString: "")
                     }
                 }
-                else
-                {
+                else {
                     content = content.stringByReplacingOccurrencesOfString("{OBJECT_MAPPER_SUPPORT}", withString: "")
                     content = content.stringByReplacingOccurrencesOfString("{INCLUDE_OBJECT_MAPPER}", withString: "")
                 }

--- a/SwiftyJSONAccelerator/SJModelGenerator.swift
+++ b/SwiftyJSONAccelerator/SJModelGenerator.swift
@@ -12,7 +12,10 @@ import Cocoa
 /**
  *  Internal Structure for storing the types of variables.
  *  - kStringType
- *  - kNumberType
+ *  - kIntNumberType
+ *  - kFloatNumberType
+ *  - kDoubleNumberType
+ *  - kCGFloatNumberType
  *  - kBoolType
  *  - kArrayType
  *  - kObjectType

--- a/SwiftyJSONAccelerator/SJModelGenerator.swift
+++ b/SwiftyJSONAccelerator/SJModelGenerator.swift
@@ -214,11 +214,19 @@ public class ModelGenerator {
             
             if self.supportNSCoding
             {
-                content = content.stringByReplacingOccurrencesOfString("{NSCODING_PROTOCOL_SUPPORT}", withString: ", NSCoding")
-                content = content.stringByReplacingOccurrencesOfString("{NSCODING_SUPPORT}", withString: "\t// MARK: NSCoding Protocol\n\trequired public init(coder aDecoder: NSCoder) {\n\t{DECODERS}\n\t}\n\n\tpublic func encodeWithCoder(aCoder: NSCoder) {\n{ENCODERS}\n\t}")
+                if let nscodingBase = try? String(contentsOfFile: NSBundle.mainBundle().pathForResource("NSCodingTemplate", ofType: "txt")!)
+                {
+                    content = content.stringByReplacingOccurrencesOfString("{NSCODING_PROTOCOL_SUPPORT}", withString: ", NSCoding")
+                    content = content.stringByReplacingOccurrencesOfString("{NSCODING_SUPPORT}", withString: nscodingBase)
 
-                content = content.stringByReplacingOccurrencesOfString("{ENCODERS}", withString: encoders)
-                content = content.stringByReplacingOccurrencesOfString("{DECODERS}", withString: decoders)
+                    content = content.stringByReplacingOccurrencesOfString("{ENCODERS}", withString: encoders)
+                    content = content.stringByReplacingOccurrencesOfString("{DECODERS}", withString: decoders)
+                }
+                else
+                {
+                    content = content.stringByReplacingOccurrencesOfString("{NSCODING_PROTOCOL_SUPPORT}", withString: "")
+                    content = content.stringByReplacingOccurrencesOfString("{NSCODING_SUPPORT}", withString: "")
+                }
             }
             else
             {

--- a/SwiftyJSONAccelerator/SJModelGenerator.swift
+++ b/SwiftyJSONAccelerator/SJModelGenerator.swift
@@ -50,6 +50,7 @@ public class ModelGenerator {
     var filePath: String
     var baseClassName: String
     var includeSwiftyJSON: Bool
+    var supportNSCoding: Bool
 
 
     /**
@@ -66,7 +67,7 @@ public class ModelGenerator {
 
      - returns: A ModelGenerator instance.
      */
-    init(baseContent: JSON, prefix: String?, baseClassName: String, authorName: String?, companyName: String?, type: String, filePath: String, includeSwiftyJSON: Bool) {
+    init(baseContent: JSON, prefix: String?, baseClassName: String, authorName: String?, companyName: String?, type: String, filePath: String, includeSwiftyJSON: Bool, supportNSCoding: Bool) {
         self.authorName = authorName
         self.baseContent = baseContent
         self.prefix = prefix
@@ -76,6 +77,7 @@ public class ModelGenerator {
         self.filePath = filePath
         self.baseClassName = baseClassName
         self.includeSwiftyJSON = includeSwiftyJSON
+        self.supportNSCoding = supportNSCoding
     }
 
     /**
@@ -193,8 +195,19 @@ public class ModelGenerator {
             content = content.stringByReplacingOccurrencesOfString("{STRING_CONSTANT_BLOCK}", withString: stringConstants)
             content = content.stringByReplacingOccurrencesOfString("{PROPERTIES}", withString: declarations)
             content = content.stringByReplacingOccurrencesOfString("{INITALIZER}", withString: initalizers)
-            content = content.stringByReplacingOccurrencesOfString("{ENCODERS}", withString: encoders)
-            content = content.stringByReplacingOccurrencesOfString("{DECODERS}", withString: decoders)
+            
+            if self.supportNSCoding
+            {
+                content = content.stringByReplacingOccurrencesOfString("{NSCODING_SUPPORT}", withString: "\t// MARK: NSCoding Protocol\n\trequired public init(coder aDecoder: NSCoder) {\n\t{DECODERS}\n\t}\n\n\tpublic func encodeWithCoder(aCoder: NSCoder) {\n{ENCODERS}\n\t}")
+
+                content = content.stringByReplacingOccurrencesOfString("{ENCODERS}", withString: encoders)
+                content = content.stringByReplacingOccurrencesOfString("{DECODERS}", withString: decoders)
+            }
+            else
+            {
+                content = content.stringByReplacingOccurrencesOfString("{NSCODING_SUPPORT}", withString: "")
+            }
+
             content = content.stringByReplacingOccurrencesOfString("{DESC}", withString: description)
 
             if authorName != nil {

--- a/SwiftyJSONAccelerator/SJModelGenerator.swift
+++ b/SwiftyJSONAccelerator/SJModelGenerator.swift
@@ -390,7 +390,7 @@ public class ModelGenerator {
      */
     internal func initalizerForVariable(variableName: String, var type: String, key: String) -> String {
         type = typeToSwiftType(type)
-        return "\t\tif let tempValue = json[\(key)].\(type) {\n\t\t\t\(variableName) = tempValue\n\t\t}"
+        return "\t\t\(variableName) = json[\(key)].\(type)\n"
     }
 
     /**
@@ -401,7 +401,7 @@ public class ModelGenerator {
      - returns: A single line declaration of the variable.
      */
     internal func initalizerForObject(variableName: String, className: String, key: String) -> String {
-        return  "\t\t\(variableName) = \(className)(json: json[\(key)])"
+        return  "\t\t\(variableName) = \(className)(json: json[\(key)])\n"
     }
 
     /**
@@ -411,7 +411,7 @@ public class ModelGenerator {
      - returns: A single line declaration of the variable.
      */
     internal func initalizerForEmptyArray(variableName: String, key: String) -> String {
-        return "\t\tif let tempValue = json[\(key)].array {\n\t\t\t\(variableName) = tempValue\n\t\t}"
+        return "\t\tif let tempValue = json[\(key)].array {\n\t\t\t\(variableName) = tempValue\n\t\t} else {\n\t\t\t\(variableName) = nil\n\t\t}\n"
     }
 
     /**
@@ -422,7 +422,7 @@ public class ModelGenerator {
      - returns: A single line declaration of the variable which is an array of object.
      */
     internal func initalizerForObjectArray(variableName: String, className: String, key: String) -> String {
-        return  "\t\t\(variableName) = []\n\t\tif let items = json[\(key)].array {\n\t\t\tfor item in items {\n\t\t\t\t\(variableName)?.append(\(className)(json: item))\n\t\t\t}\n\t\t}\n"
+        return  "\t\t\(variableName) = []\n\t\tif let items = json[\(key)].array {\n\t\t\tfor item in items {\n\t\t\t\t\(variableName)?.append(\(className)(json: item))\n\t\t\t}\n\t\t} else {\n\t\t\t\(variableName) = nil\n\t\t}\n"
     }
 
     /**
@@ -433,7 +433,7 @@ public class ModelGenerator {
      */
     internal func initalizerForPrimitiveVariableArray(variableName: String, key: String, var type: String) -> String {
         type = typeToSwiftType(type)
-        return  "\t\t\(variableName) = []\n\t\tif let items = json[\(key)].array {\n\t\t\tfor item in items {\n\t\t\t\tif let tempValue = item.\(type) {\n\t\t\t\t\(variableName)?.append(tempValue)\n\t\t\t\t}\n\t\t\t}\n\t\t}\n"
+        return  "\t\t\(variableName) = []\n\t\tif let items = json[\(key)].array {\n\t\t\tfor item in items {\n\t\t\t\tif let tempValue = item.\(type) {\n\t\t\t\t\(variableName)?.append(tempValue)\n\t\t\t\t}\n\t\t\t}\n\t\t} else {\n\t\t\t\(variableName) = nil\n\t\t}\n"
     }
 
     /**
@@ -471,7 +471,7 @@ public class ModelGenerator {
      */
     internal func initalize(variableName: String, var type: String, key: String) -> String {
         type = typeToSwiftType(type)
-        return "\t\tif let tempValue = json[\(key)].\(type) {\n\t\t\t\(variableName) = tempValue\n\t\t}"
+        return "\t\t\(variableName) = json[\(key)].\(type)\n"
     }
 
     /**


### PR DESCRIPTION
• Added checkbox to make NSCoding optional and updated creation logic.
• Added checkbox to make SwiftyJSON optional and updated creation logic.
• Added checkbox to add 'import ObjectMapper' and updated creation logic.
• Change from using NSNumber to the specific number type. (Int, Float, Double, or CGFloat)
• Removal of safety checks that SwiftyJSON already provides. (The checks also would've put the object in an inconsistent state if they ran...we're using optionals, so let's allow SwiftyJSON to nil them out if necessary)
• Abstraction of SwiftyJSON and ObjectMapper logic into separate template files.
• A few cleanups.

![screen shot 2015-10-25 at 3 00 36 am](https://cloud.githubusercontent.com/assets/1717860/10714392/96ef3be0-7ac4-11e5-86c4-f763c201ddcb.png)
