### PR TITLE
Sets the date style based on the Mac's locale, instead of a fix format

### DIFF
--- a/SwiftyJSONAccelerator/SJModelGenerator.swift
+++ b/SwiftyJSONAccelerator/SJModelGenerator.swift
@@ -600,7 +600,7 @@ public class ModelGenerator {
      */
     internal func todayDateString() -> String {
         let formatter = NSDateFormatter.init()
-        formatter.dateFormat = "dd/MM/yyyy"
+        formatter.dateStyle = .ShortStyle
         return formatter.stringFromDate(NSDate.init())
     }
 


### PR DESCRIPTION
UK Locale will have the date formatted as dd/MM/yyyy
US Locale will have the date formatted as MM/dd/yyyy
