### PR TITLE
subclassing from NSObject

### DIFF
--- a/SwiftyJSONAccelerator/SJModelGenerator.swift
+++ b/SwiftyJSONAccelerator/SJModelGenerator.swift
@@ -241,7 +241,7 @@ public class ModelGenerator {
 
                     content = content.stringByReplacingOccurrencesOfString("{OBJECT_MAPPER_INITIALIZER}", withString: objectMapperMappings)
 
-                    objectBaseClass = "Mappable"
+                    objectBaseClass = "NSObject, Mappable"
 
                     if includeObjectMapper! {
                         content = content.stringByReplacingOccurrencesOfString("{INCLUDE_OBJECT_MAPPER}", withString: "\nimport ObjectMapper")


### PR DESCRIPTION
Since Mappable is a protocol, the BaseTemplate needs something like a
{MAPPABLE_PROTOCOL_SUPPORT} in the template to set “Mappable” as a
supported protocol, if using ObjectMapper.

Without subclassing the models from NSObject, Xcode throws a weird
error when trying to archive these models
