### PR TITLE
ObjectMapper methods updated.

### DIFF
--- a/SwiftyJSONAccelerator/Base Files/ObjectMapperTemplate.txt
+++ b/SwiftyJSONAccelerator/Base Files/ObjectMapperTemplate.txt
@@ -3,7 +3,7 @@
     Map a JSON object to this class using ObjectMapper
     - parameter map: A mapping from ObjectMapper
     */
-    required init?(_ map: Map){
+    required public init?(_ map: Map){
 
     }
 
@@ -11,6 +11,6 @@
     Map a JSON object to this class using ObjectMapper
     - parameter map: A mapping from ObjectMapper
     */
-    func mapping(map: Map) {
+    public func mapping(map: Map) {
 {OBJECT_MAPPER_INITIALIZER}
     }

--- a/SwiftyJSONAccelerator/SJModelGenerator.swift
+++ b/SwiftyJSONAccelerator/SJModelGenerator.swift
@@ -386,7 +386,9 @@ public class ModelGenerator {
 
     - returns: A single line mapping for the variable
     */
-    internal func mappingForObjectMapper(variableName: String, key: String) -> String {
+    internal func mappingForObjectMapper(variableName: String, var key: String) -> String {
+        key = key.stringByReplacingOccurrencesOfString("\"", withString: "", options: NSStringCompareOptions.LiteralSearch, range: nil)
+
         return "\t\t\(variableName) <- map[\(key)]"
     }
 


### PR DESCRIPTION
I had two errors in the ObjectMapper generated files.

1 - mapping keys ""    

```
 public func mapping(map: Map) {
    width <- map["kFBBackgroundUrlWidthKey"]
    height <- map["kFBBackgroundUrlHeightKey"]
    url <- map["kFBBackgroundUrlUrlKey"]

}
```

_solution : It was extra quote marks "  I fixed via removing them._

2 - XCode compiler error for the "public" type.

```
- required init?(_ map: Map){
```

_solution : fixed via adding public init. thats all._

Thanks.
