### PR TITLE
Fixed the bug

### DIFF
--- a/SwiftyJSONAccelerator/SJModelGenerator.swift
+++ b/SwiftyJSONAccelerator/SJModelGenerator.swift
@@ -387,7 +387,7 @@ public class ModelGenerator {
     - returns: A single line mapping for the variable
     */
     internal func mappingForObjectMapper(variableName: String, key: String) -> String {
-        return "\t\t\(variableName) <- map[\"\(key)\"]"
+        return "\t\t\(variableName) <- map[\(key)]"
     }
 
     //MARK: SwiftyJSON Initalizer


### PR DESCRIPTION
the key constant will be used, instead of the constant name as a string
