### PR TITLE
Swift 3 Warnings Removed

### DIFF
--- a/SwiftyJSONAccelerator/LineNumberRulerView.swift
+++ b/SwiftyJSONAccelerator/LineNumberRulerView.swift
@@ -53,9 +53,9 @@ extension NSTextView {
         }
 
         postsFrameChangedNotifications = true
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "lnv_framDidChange:", name: NSViewFrameDidChangeNotification, object: self)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(NSTextView.lnv_framDidChange(_:)), name: NSViewFrameDidChangeNotification, object: self)
 
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "lnv_textDidChange:", name: NSTextDidChangeNotification, object: self)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(NSTextView.lnv_textDidChange(_:)), name: NSTextDidChangeNotification, object: self)
     }
 
     func lnv_framDidChange(notification: NSNotification) {
@@ -141,12 +141,12 @@ class LineNumberRulerView: NSRulerView {
                         }
 
                         // Move to next glyph line
-                        glyphLineCount++
+                        glyphLineCount += 1
                         glyphIndexForGlyphLine = NSMaxRange(effectiveRange)
                     }
 
                     glyphIndexForStringLine = NSMaxRange(glyphRangeForStringLine)
-                    lineNumber++
+                    lineNumber += 1
                 }
 
                 // Draw line number for the extra line at the end of the text

--- a/SwiftyJSONAccelerator/SJEditorViewController.swift
+++ b/SwiftyJSONAccelerator/SJEditorViewController.swift
@@ -170,16 +170,16 @@ class SJEditorViewController: NSViewController, NSTextViewDelegate {
         var lineNumber = 0
         var characterPosition = 0
         for line in string.componentsSeparatedByString("\n") {
-            lineNumber++
+            lineNumber += 1
             var columnNumber = 0
             for column in line.characters {
-                characterPosition++
-                columnNumber++
+                characterPosition += 1
+                columnNumber += 1
                 if characterPosition == position {
                     return (String(column), lineNumber, columnNumber )
                 }
             }
-            characterPosition++
+            characterPosition += 1
             if characterPosition == position {
                 return ("\n", lineNumber, columnNumber+1 )
             }

--- a/SwiftyJSONAccelerator/SJModelGenerator.swift
+++ b/SwiftyJSONAccelerator/SJModelGenerator.swift
@@ -343,8 +343,9 @@ public class ModelGenerator {
 
      - returns: A generated string that can be used to store the key of the variable in the JSON.
      */
-    internal func variableNameKeyBuilder(className: String, var variableName: String) -> String {
-        variableName.replaceRange(variableName.startIndex...variableName.startIndex, with: String(variableName[variableName.startIndex]).uppercaseString)
+    internal func variableNameKeyBuilder(className: String, variableName: String) -> String {
+        var varName = variableName
+        varName.replaceRange(variableName.startIndex...variableName.startIndex, with: String(variableName[variableName.startIndex]).uppercaseString)
         return "k\(className)\(variableName)Key"
     }
 
@@ -445,8 +446,8 @@ public class ModelGenerator {
      - parameter key:          Key against which the value is stored.
      - returns: A single line declaration of the variable which is an array of primitive kind.
      */
-    internal func initalizerForPrimitiveVariableArray(variableName: String, key: String, var type: String) -> String {
-        type = typeToSwiftType(type)
+    internal func initalizerForPrimitiveVariableArray(variableName: String, key: String, type: String) -> String {
+        let type = typeToSwiftType(type)
         return  "\t\t\(variableName) = []\n\t\tif let items = json[\(key)].array {\n\t\t\tfor item in items {\n\t\t\t\tif let tempValue = item.\(type) {\n\t\t\t\t\(variableName)?.append(tempValue)\n\t\t\t\t}\n\t\t\t}\n\t\t} else {\n\t\t\t\(variableName) = nil\n\t\t}"
     }
 
@@ -648,7 +649,8 @@ public class ModelGenerator {
      - parameter type: VariableType
      - returns: swift variable type.
      */
-    internal func typeToSwiftType(var type: String) -> String {
+    internal func typeToSwiftType( type: String) -> String {
+        var type = type
         type.replaceRange(type.startIndex...type.startIndex, with: String(type[type.startIndex]).lowercaseString)
         return type
     }

--- a/SwiftyJSONAccelerator/SwiftyJSON.swift
+++ b/SwiftyJSONAccelerator/SwiftyJSON.swift
@@ -385,7 +385,8 @@ public struct JSONGenerator : GeneratorType {
         switch self.type {
         case .Array:
             if let o = self.arrayGenerate!.next() {
-                return (String(self.arrayIndex++), JSON(o))
+                self.arrayIndex += 1
+                return (String(self.arrayIndex), JSON(o))
             } else {
                 return nil
             }


### PR DESCRIPTION
In X-code 7.3 (Swift 2.2), warnings are given for using syntax which will not be supported in Swift 3.
Those syntax are changed in this commit to offer compatibility with swift 3
