### PR TITLE
Don't set rawValue for a case if it is the same as it's name

### DIFF
--- a/Core/Generator/Model-File-Components/SwiftJSONModelFile.swift
+++ b/Core/Generator/Model-File-Components/SwiftJSONModelFile.swift
@@ -57,7 +57,8 @@ struct SwiftJSONModelFile: ModelFile {
     /// - Returns: Returns `case <constant> = "value"`.
     func genStringConstant(_ constantName: String, _ value: String) -> String {
         let component = constantName.components(separatedBy: ".")
-        return "case \(component.last!) = \"\(value)\""
+        let caseName = component.last!
+        return "case \(caseName)" + (caseName == value ? "" : " = \"\(value)\"")
     }
 
     /// Generate the variable declaration string

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.6)
+    CFPropertyList (3.0.0)
     activesupport (4.2.11.1)
       i18n (~> 0.7)
       minitest (~> 5.1)


### PR DESCRIPTION
Hello.
Thank you for this utility. It saves a lot of time.
In this pull request I fixed #98.
**Before:**
```
enum CodingKeys: String, CodingKey {
    case anyCase = "anyCase"
}
```
**After:**
```
enum CodingKeys: String, CodingKey {
    case anyCase
}
```
Updated gems.